### PR TITLE
Player dragon animation

### DIFF
--- a/devsdragons/src/components/DragonHealthBar/DragonHealthBar.jsx
+++ b/devsdragons/src/components/DragonHealthBar/DragonHealthBar.jsx
@@ -5,6 +5,7 @@ import React, {useState} from 'react';
 
 const DragonHealthBar = () => {
     const[health, setHealth] = useState(150); //random value for now (more than player)
+    const [isDragonAttacking, setIsDragonAttacking] = useState(false); // State to track player's attack animation
     //health -> variable holding current health
     //setHealth -> function to update health 
 
@@ -13,9 +14,19 @@ const DragonHealthBar = () => {
     const decreaseHealth = () => {
         setHealth((prevHealth) => Math.max(prevHealth - 10, 0)); 
     };
+    const triggerDragonAttack = () => {
+        setIsDragonAttacking(true);
+        decreaseHealth();
+        setTimeout(() => setIsDragonAttacking(false), 500);
+    };
+
 
     return ( 
         <div>
+             <button onClick={triggerDragonAttack}>Attack</button>
+
+             {isDragonAttacking && <p>Dragon Attacking!</p>}
+             
              {/* Button to decrease health */}
             <button style = {{backgroundColor: 'red', color: 'white'}} onClick= {decreaseHealth}>TakeDamage(Dragon)</button>
              {/* Display current health value */}

--- a/devsdragons/src/components/DragonHealthBar/DragonHealthBar.jsx
+++ b/devsdragons/src/components/DragonHealthBar/DragonHealthBar.jsx
@@ -3,13 +3,13 @@ import React, {useState} from 'react';
 
 
 
-const PlayerHealthBar = () => {
-    const[health, setHealth] = useState(100); //random value for now
+const DragonHealthBar = () => {
+    const[health, setHealth] = useState(150); //random value for now (more than player)
     //health -> variable holding current health
     //setHealth -> function to update health 
 
 
-    //function to decrease player's health
+    //function to decsease player's health
     const decreaseHealth = () => {
         setHealth((prevHealth) => Math.max(prevHealth - 10, 0)); 
     };
@@ -17,17 +17,17 @@ const PlayerHealthBar = () => {
     return ( 
         <div>
              {/* Button to decrease health */}
-            <button style = {{backgroundColor: 'red', color: 'white'}} onClick= {decreaseHealth}>TakeDamage(Player)</button>
+            <button style = {{backgroundColor: 'red', color: 'white'}} onClick= {decreaseHealth}>TakeDamage(Dragon)</button>
              {/* Display current health value */}
             <p>Health: {health}</p> {/*states health*/}
 
             {/*healthbar*/}
             <div style = {{width: '200px', height: '20px', backgroundColor: '#4a4a4a', position: 'relative' }}> {/*empty (outer) bar is grey*/}
-            <div style = {{width:`${health}%`, height: '100%', backgroundColor: '#b3e024'}} ></div> {/* filled (inner) bar is bright green*/}
+            <div style = {{width:`${(health / 150) * 100}%`, height: '100%', backgroundColor: '#b3e024'}} ></div> {/* filled (inner) bar is bright green*/}
             </div>
         </div>
     );
 }
 
 
-export default PlayerHealthBar;
+export default DragonHealthBar;

--- a/devsdragons/src/components/PlayerHealthBar/PlayerHealthBar.jsx
+++ b/devsdragons/src/components/PlayerHealthBar/PlayerHealthBar.jsx
@@ -5,6 +5,8 @@ import React, {useState} from 'react';
 
 const PlayerHealthBar = () => {
     const[health, setHealth] = useState(100); //random value for now
+    const [isPlayerAttacking, setIsPlayerAttacking] = useState(false); // State to track player's attack animation
+   
     //health -> variable holding current health
     //setHealth -> function to update health 
 
@@ -13,17 +15,33 @@ const PlayerHealthBar = () => {
     const decreaseHealth = () => {
         setHealth((prevHealth) => Math.max(prevHealth - 10, 0)); 
     };
+    //function to trigger player attak
+    const triggerAttack = () => {
+        setIsPlayerAttacking(true);
+        decreaseHealth();
+        setTimeout(() => setIsPlayerAttacking(false), 500); // Reset after 500ms (duration of animation)
+    };
+   
+  
+
 
     return ( 
         <div>
-             {/* Button to decrease health */}
-            <button style = {{backgroundColor: 'red', color: 'white'}} onClick= {decreaseHealth}>TakeDamage(Player)</button>
-             {/* Display current health value */}
-            <p>Health: {health}</p> {/*states health*/}
+            {/* Button to trigger the attack animation  (not working yet ) */} 
+            <button onClick={triggerAttack}>Attack</button>
 
-            {/*healthbar*/}
-            <div style = {{width: '200px', height: '20px', backgroundColor: '#4a4a4a', position: 'relative' }}> {/*empty (outer) bar is grey*/}
-            <div style = {{width:`${health}%`, height: '100%', backgroundColor: '#b3e024'}} ></div> {/* filled (inner) bar is bright green*/}
+            {/*attack animation placeholder for now*/}
+            {isPlayerAttacking && <p>Player Attacking!</p>}
+           
+            {/* Button to decrease health */}
+            <button style={{ backgroundColor: 'red', color: 'white' }} onClick={decreaseHealth}>TakeDamage(Player)</button>
+
+            {/* Display current health value */}
+            <p>Health: {health}</p>
+
+            {/* Health bar */}
+            <div style={{ width: '200px', height: '20px', backgroundColor: '#4a4a4a', position: 'relative' }}>
+                <div style={{ width: `${health}%`, height: '100%', backgroundColor: '#b3e024' }}></div>
             </div>
         </div>
     );

--- a/devsdragons/src/views/Examples/DragonHealthBarEx.jsx
+++ b/devsdragons/src/views/Examples/DragonHealthBarEx.jsx
@@ -1,0 +1,13 @@
+// src/views/Examples/DragonHealthBarEx.jsx
+import React from 'react';
+import DragonHealthBar from '../../components/DragonHealthBar/DragonHealthBar.jsx';
+
+const DragonHealthBarEx = () => {
+    return (
+        <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'flex-start', height: '100vh'}}>
+            <DragonHealthBar />
+        </div>
+    );
+};
+
+export default DragonHealthBarEx;


### PR DESCRIPTION
added placeholders in the player and dragon health components to show "attacking" text when an attack is triggered, simulating an animation. Should be later replaced with sequences of sprite images and animation logic